### PR TITLE
Fix SQL query to search books by name

### DIFF
--- a/server/routes.py
+++ b/server/routes.py
@@ -13,7 +13,7 @@ def index():
 
     if name:
         cursor.execute(
-            "SELECT * FROM books WHERE author LIKE %s", author
+            "SELECT * FROM books WHERE name LIKE '%" + name + "%'"
         )
         books = [Book(*row) for row in cursor]
 


### PR DESCRIPTION
This pull request makes a small change to the SQL query in the `index` function of `server/routes.py`, updating the search to filter by book name instead of author, and using a pattern match for partial name matches.